### PR TITLE
Replaces array spreads on large arrays with safer methods

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -4,7 +4,7 @@
 // export const server = 'http://127.0.0.1:8000/api/v1/';
 
 // production server
-export const server = 'https://api-adage.greenelab.com/api/v1/';
+export const server = 'https://api-mousiplier.greenelab.com/api/v1/';
 
 // default result limit
 export const defaultLimit = 100;

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -10,4 +10,4 @@ export const server = 'https://api-mousiplier.greenelab.com/api/v1/';
 export const defaultLimit = 100;
 
 // max result limit
-export const maxLimit = 999999;
+export const maxLimit = 9999999; // old value: 999999

--- a/src/pages/experiments/activities/controls/index.js
+++ b/src/pages/experiments/activities/controls/index.js
@@ -10,6 +10,7 @@ import { downloadImage } from './download';
 import { downloadTable } from './download';
 import { isArray } from '../../../../util/types';
 import { toExponential } from '../../../../util/string';
+import { arrayMin, arrayMax } from '../../../../util/math';
 
 import { ReactComponent as LoadingIcon } from '../../../../images/loading.svg';
 import { ReactComponent as BiArrowIcon } from '../../../../images/bi-arrow.svg';
@@ -167,8 +168,8 @@ const mapStateToProps = (state) => {
   let max = 0;
   if (isArray(activities)) {
     const values = activities.map((activity) => activity.value);
-    min = Math.min(...values);
-    max = Math.max(...values);
+    min = arrayMin(values); // Math.min(...values);
+    max = arrayMax(values); // Math.max(...values);
   }
   return { min, max };
 };

--- a/src/pages/signatures/activities/index.js
+++ b/src/pages/signatures/activities/index.js
@@ -6,6 +6,7 @@ import Table from './table';
 import Controls from './controls';
 import { isString } from '../../../util/types';
 import { isArray } from '../../../util/types';
+import { arrayMin, arrayMax } from '../../../util/math';
 
 import './index.css';
 
@@ -44,8 +45,8 @@ export const mapActivities = (activities, state) => {
 
   // get all activities in signature, and min/max
   const values = activities.map((activity) => activity.value);
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const min = arrayMin(values); // Math.min(...values);
+  const max = arrayMax(values); // Math.max(...values);
   const bySignature = { values, min, max };
 
   // get sample info out of activities
@@ -64,8 +65,8 @@ export const mapActivities = (activities, state) => {
         .map((sample) => sample.value)
         .filter((value) => value);
       // get min/max/range of values
-      const min = Math.min(...values);
-      const max = Math.max(...values);
+      const min = arrayMin(values); // Math.min(...values);
+      const max = arrayMax(values); // Math.max(...values);
       const range = max - min;
       // return all needed info
       return {

--- a/src/util/math.js
+++ b/src/util/math.js
@@ -328,3 +328,22 @@ export const calculateEnrichedGenes = ({
 
 // arbitrary cutoff below which p values have no meaning
 export const epsilon = 1e-8;
+
+// array min and max implementations that won't explode the stack; (e.g.,
+// Math.min(...values) will raise a "maximum stack size exceeded" error if
+// values is too large, since arguments to functions are stored on the stack.)
+export const arrayMin = (values) => {
+  let minVal = values[0];
+  for (let x of values) {
+    if (x < minVal) { minVal = x; }
+  }
+  return minVal;
+}
+
+export const arrayMax = (values) => {
+  let maxVal = values[0];
+  for (let x of values) {
+    if (x > maxVal) { maxVal = x; }
+  }
+  return maxVal;
+}


### PR DESCRIPTION
The backend now returns significantly more data from certain endpoints, which has caused operations that were safe before to now raise issues. This PR addresses the use of the spread operator on an array to fill out the arguments of `Math.max()` and `Math.min()`, e.g. `Math.max(...myLargeArray)`. JS allocates a fixed amount of memory for the call stack, and that memory needs to hold arguments to function invocations on the stack; pushing too many arguments to a function will overflow that memory and cause a stack overflow exception.

This PR replaces the problematic spread calls (i.e., the ones that were crashing the signatures page) with `arrayMax()` and `arrayMin()`, which iterate over the values in the array and return the maximum or minimum, respectively.

(Just FYI there are more uses of the spread operator in the codebase, but I wasn't sure if they needed to be replaced, too. Unfortunately, this PR also includes updating the API url and changing the `maxLimit` constant that's used to pull all entities from an endpoint, but in the interest of getting this out I left those changes in.)