### PR TITLE
improve signatures tab/page performance

### DIFF
--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -264,7 +264,7 @@ const Body = () => {
 
   return (
     <div className='tbody' style={{ minWidth }}>
-      {table.map((row, rowIndex) => (
+      {table.slice(0, 100).map((row, rowIndex) => (
         <BodyRow key={rowIndex} row={row} rowIndex={rowIndex} />
       ))}
     </div>

--- a/src/pages/signatures/activities/index.js
+++ b/src/pages/signatures/activities/index.js
@@ -49,20 +49,18 @@ export const mapActivities = (activities, state) => {
   const max = arrayMax(values); // Math.max(...values);
   const bySignature = { values, min, max };
 
-  // get sample info out of activities
-  const findSample = (sample) => ({
-    id: sample,
-    value: activities.find((activity) => activity.sample === sample)?.value
-  });
+  // bring sample info out of activities and into map
+  const activityMap = {};
+  for (const { sample, value } of activities) activityMap[sample] = value;
 
   // get activities by experiment
   const byExperiment = state.experiments.list
     .map((experiment) => {
       // get experiment samples info
-      const samples = experiment.samples.map(findSample);
+      const samples = experiment.samples;
       // get activity value of each sample
       const values = samples
-        .map((sample) => sample.value)
+        .map((sample) => activityMap[sample])
         .filter((value) => value);
       // get min/max/range of values
       const min = arrayMin(values); // Math.min(...values);

--- a/src/pages/signatures/participating/index.js
+++ b/src/pages/signatures/participating/index.js
@@ -35,11 +35,16 @@ Selected = connect(mapStateToProps)(Selected);
 
 export default Selected;
 
-export const mapParticipations = (state) =>
-  isArray(state.signatures.participations) && isArray(state.genes.list) ?
-    state.signatures.participations.map((participation) => ({
-      ...(state.genes.list.find((gene) => gene.id === participation.gene) ||
-          {}),
-      weight: participation.weight
-    })) :
-    state.signatures.participations;
+export const mapParticipations = (state) => {
+  if (!isArray(state.signatures.participations) || !isArray(state.genes.list))
+    return state.signatures.participations;
+
+  // bring gene list into map by id
+  const geneMap = {};
+  for (const { id, ...rest } of state.genes.list) geneMap[id] = { id, ...rest };
+
+  return state.signatures.participations.map((participation) => ({
+    ...(geneMap[participation.gene] || {}),
+    weight: participation.weight
+  }));
+};


### PR DESCRIPTION
The main problem was the map activities and participation functions, which were cross referencing 2 sets of large arrays to fill in details, e.g. 190k participations x 10k experiments = a lot of processing. This PR uses objects (hashes) for fast lookup of things, improving performance.

I also limited the table component to showing 100 rows, which also improves rendering performance. Sorting should still show the true maxes/mins because the table still has access to the full data set, it just renders the first 100.