### PR TITLE
Silhouette scores

### DIFF
--- a/src/pages/signatures/activities/controls/download.js
+++ b/src/pages/signatures/activities/controls/download.js
@@ -3,6 +3,7 @@ import { downloadTsv } from '../../../../util/download';
 export const downloadTable = ({ byExperiment }) => {
   const data = byExperiment.map((activity) => ({
     'Experiment': activity.accession,
+    'Silhouette Score': activity.score,
     'Activity Range': activity.range,
     'Min Activity': activity.min,
     'Max Activity': activity.max

--- a/src/pages/signatures/activities/index.js
+++ b/src/pages/signatures/activities/index.js
@@ -1,21 +1,21 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React from "react";
+import { connect } from "react-redux";
 
-import FetchAlert from '../../../components/fetch-alert';
-import Table from './table';
-import Controls from './controls';
-import { isString } from '../../../util/types';
-import { isArray } from '../../../util/types';
-import { arrayMin, arrayMax } from '../../../util/math';
+import FetchAlert from "../../../components/fetch-alert";
+import Table from "./table";
+import Controls from "./controls";
+import { isString } from "../../../util/types";
+import { isArray } from "../../../util/types";
+import { arrayMin, arrayMax } from "../../../util/math";
 
-import './index.css';
+import "./index.css";
 
 // signature activities section
 
 let Activities = ({ activities }) => (
   <>
     {isString(activities) && (
-      <FetchAlert status={activities} subject='activities' />
+      <FetchAlert status={activities} subject="activities" />
     )}
     {isArray(activities) && (
       <>
@@ -27,7 +27,7 @@ let Activities = ({ activities }) => (
 );
 
 const mapStateToProps = (state) => ({
-  activities: state.signatures.activities
+  activities: state.signatures.activities,
 });
 
 Activities = connect(mapStateToProps)(Activities);
@@ -66,6 +66,8 @@ export const mapActivities = (activities, state) => {
       const min = arrayMin(values); // Math.min(...values);
       const max = arrayMax(values); // Math.max(...values);
       const range = max - min;
+      // get silhouette score
+      const score = experiment.signatureScores[state.signatures.selected.id] || 0;
       // return all needed info
       return {
         id: experiment.id,
@@ -75,10 +77,13 @@ export const mapActivities = (activities, state) => {
         min,
         max,
         range,
-        samples
+        score,
+        samples,
       };
     })
     .filter((experiment) => experiment.count);
+
+  console.log(byExperiment);
 
   return { bySignature, byExperiment };
 };

--- a/src/pages/signatures/activities/index.js
+++ b/src/pages/signatures/activities/index.js
@@ -1,21 +1,21 @@
-import React from "react";
-import { connect } from "react-redux";
+import React from 'react';
+import { connect } from 'react-redux';
 
-import FetchAlert from "../../../components/fetch-alert";
-import Table from "./table";
-import Controls from "./controls";
-import { isString } from "../../../util/types";
-import { isArray } from "../../../util/types";
-import { arrayMin, arrayMax } from "../../../util/math";
+import FetchAlert from '../../../components/fetch-alert';
+import Table from './table';
+import Controls from './controls';
+import { isString } from '../../../util/types';
+import { isArray } from '../../../util/types';
+import { arrayMin, arrayMax } from '../../../util/math';
 
-import "./index.css";
+import './index.css';
 
 // signature activities section
 
 let Activities = ({ activities }) => (
   <>
     {isString(activities) && (
-      <FetchAlert status={activities} subject="activities" />
+      <FetchAlert status={activities} subject='activities' />
     )}
     {isArray(activities) && (
       <>
@@ -27,7 +27,7 @@ let Activities = ({ activities }) => (
 );
 
 const mapStateToProps = (state) => ({
-  activities: state.signatures.activities,
+  activities: state.signatures.activities
 });
 
 Activities = connect(mapStateToProps)(Activities);
@@ -83,8 +83,6 @@ export const mapActivities = (activities, state) => {
       };
     })
     .filter((experiment) => experiment.count && experiment.score);
-
-  console.log(byExperiment);
 
   return { bySignature, byExperiment };
 };

--- a/src/pages/signatures/activities/index.js
+++ b/src/pages/signatures/activities/index.js
@@ -67,7 +67,8 @@ export const mapActivities = (activities, state) => {
       const max = arrayMax(values); // Math.max(...values);
       const range = max - min;
       // get silhouette score
-      const score = experiment.signatureScores[state.signatures.selected.id] || 0;
+      const score =
+        experiment.signatureScores[state.signatures.selected.id] || 0;
       // return all needed info
       return {
         id: experiment.id,
@@ -81,7 +82,7 @@ export const mapActivities = (activities, state) => {
         samples,
       };
     })
-    .filter((experiment) => experiment.count);
+    .filter((experiment) => experiment.count && experiment.score);
 
   console.log(byExperiment);
 

--- a/src/pages/signatures/activities/table/index.js
+++ b/src/pages/signatures/activities/table/index.js
@@ -62,13 +62,13 @@ let Table = ({ bySignature = {}, byExperiment = [], sampleList }) => {
                 </button>
               );
             },
-            width: '30%',
+            width: '20%',
             align: 'center'
           },
           {
             name: 'Activities',
             key: 'count',
-            width: '7%',
+            width: '10%',
             align: 'center'
           },
           {
@@ -76,27 +76,32 @@ let Table = ({ bySignature = {}, byExperiment = [], sampleList }) => {
             key: 'samples',
             value: ({ cell }) => cell.length,
             render: ({ cell }) => cell.length,
-            width: '7%',
+            width: '10%',
             align: 'center'
           },
           {
             name: 'Min',
             key: 'min',
-            width: '12%'
+            width: '10%'
           },
           {
             name: 'Max',
             key: 'max',
-            width: '12%'
+            width: '10%'
           },
           {
             name: 'Range',
             key: 'range',
-            width: '12%'
+            width: '10%'
+          },
+          {
+            name: 'Silhouette Score',
+            key: 'score',
+            width: '10%'
           }
         ]}
         minWidth='600px'
-        defaultSortKey='range'
+        defaultSortKey='score'
         defaultSortUp={true}
         freezeCol={false}
       />


### PR DESCRIPTION
Add silhouette scores to experiments table on signatures page, sort by that col by default, add col to CSV download, filter out null scores.

<img width="988" alt="Screenshot 2022-11-29 at 5 34 31 PM" src="https://user-images.githubusercontent.com/8326331/204663255-6d7574e2-25d1-4057-b250-dfaad4cc14cb.png">
