### PR TITLE
change sig page links to latent variables

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -65,7 +65,7 @@ const App = () => (
       <Switch>
         <Route path='/genes' component={Genes} />
         <Route path='/experiments' component={Experiments} />
-        <Route path='/signatures' component={Signatures} />
+        <Route path='/latent-variables' component={Signatures} />
         <Route path='/about' component={About} />
         <Route path='/model/:id' component={Model} />
         <Route path='/organism/:id' component={Organism} />

--- a/src/pages/experiments/activities/heatmap/index.js
+++ b/src/pages/experiments/activities/heatmap/index.js
@@ -108,7 +108,7 @@ let Heatmap = ({ activities, group }) => {
       .attr('data-tooltip-h-align', 'right')
       .on('click', (event, d) => {
         const location = window.location;
-        const to = '/signatures';
+        const to = '/latent-variables';
         const search = { signature: d.signature.id };
         history.push(getLinkPath({ location, to, search }).full);
       });

--- a/src/pages/experiments/volcano/plot/index.js
+++ b/src/pages/experiments/volcano/plot/index.js
@@ -131,7 +131,7 @@ let Plot = ({ volcano, search, pValueCutoff }) => {
       .attr('data-tooltip-speed', 10)
       .on('click', (event, d) => {
         const location = window.location;
-        const to = '/signatures';
+        const to = '/latent-variables';
         const search = { signature: d.id };
         history.push(getLinkPath({ location, to, search }).full);
       });

--- a/src/pages/header/nav/button/index.js
+++ b/src/pages/header/nav/button/index.js
@@ -14,7 +14,7 @@ const Button = ({ icon = <></>, text = '' }) => {
   return (
     <Clickable
       className='nav_button size_medium'
-      to={'/' + text.toLowerCase()}
+      to={'/' + text.toLowerCase().replaceAll(/\s+/g, '-')}
       icon={icon}
       text={text}
       flip

--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -55,7 +55,7 @@ const Home = () => (
         image={signatures1}
         icon={<SignatureIcon />}
         text='Explore Latent Variables'
-        to='/signatures'
+        to='/latent-variables'
       >
         Understand the Mousiplier latent variables by exploring the
         genes that contribute, the experiments in which they vary the most, and

--- a/src/pages/signature/link.js
+++ b/src/pages/signature/link.js
@@ -10,7 +10,7 @@ const SignatureLink = ({ signature = {} }) => {
 
   return (
     <Clickable
-      to='/signatures'
+      to='/latent-variables'
       search={{ signature: id }}
       text={label}
       link

--- a/src/pages/signatures/search/index.js
+++ b/src/pages/signatures/search/index.js
@@ -39,7 +39,7 @@ let Search = ({ model, list, results, select, search }) => {
         select({ id: results[highlightedIndex].id })
       }
       SingleComponent={<Single />}
-      storageKey='signaturesearch'
+      storageKey='latentvariablesearch'
     />
   );
 };


### PR DESCRIPTION
Changes `/signatures` route to `/latent-variables`. Changes header nav bar button and all other links to route.